### PR TITLE
PR Flip the lightning sprite

### DIFF
--- a/src/gfxEngine/GameEntity.cpp
+++ b/src/gfxEngine/GameEntity.cpp
@@ -105,7 +105,16 @@ void GameEntityBoom::Animate(float delay) {
 
 
 GameEntityLightning::GameEntityLightning(float m_x, float m_y, int m_type) : GameEntity(m_x, m_y, m_type){
+  width = 0;
+  height = 0;
+}
 
+void GameEntityLightning::SetTexture(sf::Texture &texture){
+  sprite.setTexture(texture);
+  sprite.setColor(sf::Color(255, 255, 255, 128));
+
+  width = sprite.getTexture()->getSize().x;
+  height = sprite.getTexture()->getSize().y;
 }
 
 void GameEntityLightning::Animate(float delay) {
@@ -123,9 +132,11 @@ void GameEntityLightning::Animate(float delay) {
 
     sprite.setColor(sf::Color(255, 255, 255, 255 * fade));
 
-    // FIXME: Write an equivalent for flipping in SFML2
-    // sprite.FlipX(rand()%2 == 0);
-    // sprite.FlipY(rand()%2 == 0);
+    bool flipX = rand()%2 == 0;
+    bool flipY = rand()%2 == 0;
+
+    sprite.setTextureRect(sf::IntRect(flipX ? width : 0, flipY ? height : 0,
+                                      flipX ? -width : width, flipY ? -height : height));
 }
 
 

--- a/src/gfxEngine/GameEntity.h
+++ b/src/gfxEngine/GameEntity.h
@@ -88,6 +88,10 @@ class GameEntityLightning : public GameEntity {
 public:
     GameEntityLightning(float m_x, float m_y, int m_type);
     virtual void Animate(float delay);
+    void SetTexture(sf::Texture &texture);
+private:
+  int width;
+  int height;
 };
 
 class GameEntityFlyingText : public GameEntity {

--- a/src/gfxEngine/GfxEngine.cpp
+++ b/src/gfxEngine/GfxEngine.cpp
@@ -1511,12 +1511,9 @@ void GfxEngine::createLightningEffect(GameModel* gameModel)
             }
         }
         if (isLightning) {
-                GameEntity* entity=new GameEntityLightning(OFFSET_X + i * TILE_W, OFFSET_Y, GameEntity::typeSprite);
+                GameEntityLightning* entity=new GameEntityLightning(OFFSET_X + i * TILE_W, OFFSET_Y, GameEntity::typeSprite);
                 entity->lifetime=0.6f;
-                sf::Sprite sprite;
-                sprite.setTexture(lightningVImage);
-                sprite.setColor(sf::Color(255, 255, 255, 128));
-                entity->sprite=sprite;
+                entity->SetTexture(lightningVImage);
                 EM->Add(entity);
         }
     }
@@ -1529,12 +1526,9 @@ void GfxEngine::createLightningEffect(GameModel* gameModel)
             }
         }
         if (isLightning) {
-                GameEntity* entity=new GameEntityLightning(OFFSET_X, OFFSET_Y + j * TILE_H, GameEntity::typeSprite);
+                GameEntityLightning* entity=new GameEntityLightning(OFFSET_X, OFFSET_Y + j * TILE_H, GameEntity::typeSprite);
                 entity->lifetime=0.6f;
-                sf::Sprite sprite;
-                sprite.setTexture(lightningHImage);
-                sprite.setColor(sf::Color(255, 255, 255, 128));
-                entity->sprite=sprite;
+                entity->SetTexture(lightningHImage);
                 EM->Add(entity);
         }
     }


### PR DESCRIPTION
Lightning rendering is working as it used to be now.
I'm using new texture coordinates definition instead of scale to flip the sprite.
